### PR TITLE
Fix for the operators guide section #128; fix for link in faq/how-doe…

### DIFF
--- a/docs/faq/how-does-neon-work.md
+++ b/docs/faq/how-does-neon-work.md
@@ -116,7 +116,7 @@ following items:
 on the client side.
 
 
-### I'm a dApp developer and I don't want to use the Neon Web3 Proxy. How will this impact my project?
+### I am a dApp developer and I don't want to use the Neon Web3 Proxy. How will this impact my project?
 
 The Neon Web3 Proxy can be implemented as a library, but implementation isn't simple. The most complex part of Neon Web3 Proxy implementation is the iterative transaction execution. The Neon Web3 Proxy forms Solana transactions, marking the number of VM steps to be executed without exceeding the BPF instruction limit of the Solana VM. The Neon Web3 Proxy traces the process of Neon transaction execution, sending transactions for the continuation of the suspended Neon transaction, awaiting its full execution. So if you don't want to use the Neon Web3 Proxy, you will still need to implement its functionality in your client.
 

--- a/docs/proxy/operator_guide.md
+++ b/docs/proxy/operator_guide.md
@@ -66,8 +66,6 @@ The following software should be installed on your Neon EVM proxy:
   * Docker
   * Docker Compose
 
-> Docker is used only for development purposes. Running an operator inside Docker for a live network is not recommended due to Docker's overall containerization overhead and the resulting performance degradation.
-
 ### Solana cluster requirements (optional)
 If you want to use a local solana cluster, you need to meet the following requirements:
   * Solana cluster with `--enable-rpc-transaction-history` enabled.


### PR DESCRIPTION
There two minor changes for two files: one for operator's guide and another for FAQ-file (fix for the link path)