### PR TITLE
Update of opcode, precompiles and erc20-fo-rspl documentation

### DIFF
--- a/docs/developing/deploy_facilities/interacting_with_spl_tokens.md
+++ b/docs/developing/deploy_facilities/interacting_with_spl_tokens.md
@@ -70,49 +70,26 @@ How you set up the ERC-20 Factory Contract will determine the contract deployed 
  <TabItem value="Constructor non-mintable" label="ERC20-For-Spl Constructor" default>
 
 ```
-constructor(
-     bytes32 _tokenMint
-)
-Arguments:
-_tokenMint – address of SPL token account
-Constructor signature for Mintable token is:
-constructor(
-<!--      string memory _name,
-     string memory _symbol, Is this to be removed for non-mintable?? -->
-     uint8 _decimals,
-     address _mint_authority
-)
-Arguments:
-_name – string representing full name of the token 
-_symbol – string representing shorten symbol of the token 
-_decimals – decimals of new token
-_mint_authority – address of mint/freeze authority Neon account
+/// @notice ERC20ForSpl constructor
+/// @param _tokenMint The Solana-like address of the Token Mint on Solana in bytes32 format
+constructor(bytes32 _tokenMint)
 ```
  </TabItem>
 <TabItem value="Constructor mintable" label="ERC20-For-Spl-Mintable Constructor">
 
 ``` 
+/// @notice ERC20ForSplMintable constructor
+/// @dev parameter _decimals cannot be bigger than 9, because of Solana's maximum value limit of uint64
+/// @param _name The name of the SPLToken
+/// @param _symbol The symbol of the SPLToken
+/// @param _decimals The decimals of the SPLToken
+/// @param _mint_authority The owner of the ERC20ForSPLMintable contract which has the permissions to mint new tokens
 constructor(
-     string memory _name,
-     string memory _symbol,
-     bytes32 _tokenMint
+    string memory _name,
+    string memory _symbol,
+    uint8 _decimals,
+    address _mint_authority
 )
-Arguments:
-_name – string representing full name of the token 
-_symbol – string representing shorten symbol of the token 
-_tokenMint – address of SPL token account
-Constructor signature for mintable token is:
-constructor(
-     string memory _name,
-     string memory _symbol,
-     uint8 _decimals,
-     address _mint_authority
-)
-Arguments:
-_name – string representing full name of the token 
-_symbol – string representing shorten symbol of the token 
-_decimals – decimals of new token
-_mint_authority – address of mint/freeze authority Neon account 
 ```
  </TabItem>
 </Tabs>

--- a/docs/developing/deploy_facilities/interacting_with_spl_tokens.md
+++ b/docs/developing/deploy_facilities/interacting_with_spl_tokens.md
@@ -36,7 +36,7 @@ Depending on the method called and the arguments passed to this contract, two va
 
 ### ERC-20-for-SPL
 
-The [ERC-20-for-SPL variant](https://github.com/neonlabsorg/neon-evm/blob/4bcae0f476721e5396916c43396ec85e465f878f/evm_loader/solidity/erc20_for_spl_factory.sol#L17) works with a precompiled contract within Neon EVM which can call the SPL token program. This enables you to utilize existing SPL tokens e.g. SOL or USDC, as wSOL or USDC tokens on Neon EVM chain, respectively, via the ERC-20 interface that this contract assigns the to the token.
+The [ERC-20-for-SPL variant](https://github.com/neonlabsorg/neon-evm/blob/4bcae0f476721e5396916c43396ec85e465f878f/evm_loader/solidity/erc20_for_spl_factory.sol#L17) works with a precompiled contract within Neon EVM which can call the SPL token program. This enables you to utilize existing SPL tokens e.g. SOL or USDC, as wSOL or USDC tokens on Neon EVM chain, respectively, via the ERC-20 interface.
 
 :::info
 Note that before setting up the ERC-20 Factory Contract to construct an ERC-20-for-SPL, you must register the token's existing [Metaplex metadata](https://developers.metaplex.com/token-metadata).
@@ -83,7 +83,7 @@ constructor(bytes32 _tokenMint)
 /// @param _name The name of the SPLToken
 /// @param _symbol The symbol of the SPLToken
 /// @param _decimals The decimals of the SPLToken
-/// @param _mint_authority The owner of the ERC20ForSPLMintable contract which has the permissions to mint new tokens
+/// @param _mint_authority The owner of the ERC20ForSPLMintable contract, which has the permissions to mint new tokens
 constructor(
     string memory _name,
     string memory _symbol,

--- a/docs/developing/deploy_facilities/interacting_with_spl_tokens.md
+++ b/docs/developing/deploy_facilities/interacting_with_spl_tokens.md
@@ -93,6 +93,9 @@ constructor(
 ```
  </TabItem>
 </Tabs>
+:::important
+It's highly desirable to not place `decimals` greater than 9. Neglecting this restricion may lead to issues with math operations inside the smart contract.
+:::
 
 ## Notes on usage
 

--- a/docs/developing/deploy_facilities/interacting_with_spl_tokens.md
+++ b/docs/developing/deploy_facilities/interacting_with_spl_tokens.md
@@ -39,7 +39,7 @@ Depending on the method called and the arguments passed to this contract, two va
 The [ERC-20-for-SPL variant](https://github.com/neonlabsorg/neon-evm/blob/4bcae0f476721e5396916c43396ec85e465f878f/evm_loader/solidity/erc20_for_spl_factory.sol#L17) works with a precompiled contract within Neon EVM which can call the SPL token program. This enables you to utilize existing SPL tokens e.g. SOL or NEON, as wSOL or wNEON, respectively, via the ERC-20 interface, i.e. this contract assigns the to the token.
 
 :::info
-Note that before setting up the ERC-20 Factory Contract to construct an ERC-20-for-SPL, you must register the token's existing [Metaplex metadata](https://docs.metaplex.com/programs/token-metadata/overview).
+Note that before setting up the ERC-20 Factory Contract to construct an ERC-20-for-SPL, you must register the token's existing [Metaplex metadata](https://developers.metaplex.com/token-metadata).
 :::
 
 ### ERC-20-for-SPL-Mintable

--- a/docs/developing/deploy_facilities/interacting_with_spl_tokens.md
+++ b/docs/developing/deploy_facilities/interacting_with_spl_tokens.md
@@ -46,6 +46,15 @@ Note that before setting up the ERC-20 Factory Contract to construct an ERC-20-f
 
 The [ERC-20-for-SPL-Mintable variant](https://github.com/neonlabsorg/neon-evm/blob/4bcae0f476721e5396916c43396ec85e465f878f/evm_loader/solidity/erc20_for_spl_factory.sol#LL35C1-L35C1) has two additional methods that enable you to use the Neon EVM to mint a new SPL token and register it to the interface to be ERC-20-compatible. When the ERC-20 Factory Contract is constructed to this variant, it creates a new SPL token using Solana's Token Program and provides mint and freeze authority to the Neon account specified in the constructor.
 
+## Deploying
+Setting up the ERC-20-for-SPL interface could be a 1-step or 2-step process:
+- You already have an existing SPLToken on Solana:
+  1. In this case, you only have to submit a transaction on Neon EVM to create the smart contract instance for the SPLToken.
+- You don't have an existing SPLToken and decided to use ERC-20-for-SPL-Mintable to mint a new SPLToken and to create smart contract instance:
+  1. Here, you can pass a single transaction to Neon EVM chain.
+- You don't have an existing SPLToken, but you want to be the owner of the token in the context of Solana:
+  1. Firstly, you need to deploy the SPLToken on Solana with a Solana transaction.
+  2. Next step is a transaction to Neon EVM to create the smart contract instance for the SPLToken you just deployed in the step 1.
 
 ## Contract signing
 

--- a/docs/developing/deploy_facilities/interacting_with_spl_tokens.md
+++ b/docs/developing/deploy_facilities/interacting_with_spl_tokens.md
@@ -36,7 +36,7 @@ Depending on the method called and the arguments passed to this contract, two va
 
 ### ERC-20-for-SPL
 
-The [ERC-20-for-SPL variant](https://github.com/neonlabsorg/neon-evm/blob/4bcae0f476721e5396916c43396ec85e465f878f/evm_loader/solidity/erc20_for_spl_factory.sol#L17) works with a precompiled contract within Neon EVM which can call the SPL token program. This enables you to utilize existing SPL tokens e.g. SOL or NEON, as wSOL or wNEON, respectively, via the ERC-20 interface, i.e. this contract assigns the to the token.
+The [ERC-20-for-SPL variant](https://github.com/neonlabsorg/neon-evm/blob/4bcae0f476721e5396916c43396ec85e465f878f/evm_loader/solidity/erc20_for_spl_factory.sol#L17) works with a precompiled contract within Neon EVM which can call the SPL token program. This enables you to utilize existing SPL tokens e.g. SOL or USDC, as wSOL or USDC tokens on Neon EVM chain, respectively, via the ERC-20 interface that this contract assigns the to the token.
 
 :::info
 Note that before setting up the ERC-20 Factory Contract to construct an ERC-20-for-SPL, you must register the token's existing [Metaplex metadata](https://developers.metaplex.com/token-metadata).

--- a/docs/evm_compatibility/opcodes.md
+++ b/docs/evm_compatibility/opcodes.md
@@ -15,7 +15,6 @@ Neon EVM supports the majority of the [Ethereum OpCodes](https://ethereum.org/en
 |41|COINBASE|always returns zero|
 |44|PREVRANDAO (FKA DIFFICULTY)|always returns zero|
 |45|GASLIMIT|always returns U256::MAX|
-|48|BASEFEE|always returns zero|
 |5A|GAS|returns the gas limit in the transaction instead of remaining gas|
 
 

--- a/docs/evm_compatibility/precompiles.md
+++ b/docs/evm_compatibility/precompiles.md
@@ -9,7 +9,7 @@ comment: We need to get the custom precompile addresses
 
 ## Precompiled EVM contracts
 
-Currently, Neon EVM supports the majority of [precompiled contracts](https://www.evm.codes/precompiled?fork=merge)
+Neon EVM supports the majority of Ethereum's [precompiled contracts](https://www.evm.codes/precompiled?fork=merge)
 
 | Address | Name             | Compatibility                        |
 | ------- | ---------------- | ------------------------------------ |
@@ -23,3 +23,15 @@ Currently, Neon EVM supports the majority of [precompiled contracts](https://www
 | 0x08    | ecPairing        | ![Supported](img/done.ico)           |
 | 0x09    | blake2f          | ![Supported](img/done.ico)           |
 | 0x0a    | point evaluation | ![Not Supported](img/false-copy.png) |
+
+
+Neon EVM extends EVM functionality with custom precompiles that enable integration with Solana's advanced features. The table below details each precompile:
+
+| Address                                    |	Purpose                                                                                                |	Use case                                                                                                              |	Code reference                                                                                                       |
+| ------------------------------------------ | ------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------- |
+| 0xff00000000000000000000000000000000000001 |	Deprecated – Previously supported ERC20ForSPL.  No longer in use.                                      | Not applicable.                                                                                                        |	Not available.                                                                                                       |
+| 0xff00000000000000000000000000000000000002 |	Reads data from Solana accounts by specifying byte offsets and lengths.	                               | Enables integrations with Chainlink and Pyth by extracting precise account data.                                       |	[QueryAccount.sol](https://github.com/neonlabsorg/neon-contracts/blob/main/contracts/precompiles/QueryAccount.sol)   |
+| 0xff00000000000000000000000000000000000003 |	Facilitates native token transfers between Neon and Solana.                                            |	Powers NeonPass and the @neonevm/token-transfer-core library for seamless token transfers.                            |	[INeonWithdraw.sol](https://github.com/neonlabsorg/neon-contracts/blob/main/contracts/precompiles/INeonWithdraw.sol) |
+| 0xff00000000000000000000000000000000000004 |	Acts as a Solidity interface to the SPLToken program on Solana.                                        |	Allows Solidity developers to mint, transfer, and manage SPLTokens directly within the Neon EVM.                      |	[ISPLToken.sol](https://github.com/neonlabsorg/neon-contracts/blob/main/contracts/precompiles/ISPLToken.sol)         |
+| 0xff00000000000000000000000000000000000005 |	Provides a Solidity interface for the Metaplex program on Solana.                                      |	Empowers developers to set and manage metadata for SPLTokens, enabling advanced token customization.                  |	[IMetaplex.sol](https://github.com/neonlabsorg/neon-contracts/blob/main/contracts/precompiles/IMetaplex.sol)         |
+| 0xff00000000000000000000000000000000000006 |	Enables composability by initiating Solana instructions and receiving responses at the Solidity level. |	Supports various actions such as SPLToken transfers, DEX swaps, and interactions with Solana-based lending protocols. |	[ICallSolana.sol](https://github.com/neonlabsorg/neon-contracts/blob/main/contracts/precompiles/ICallSolana.sol)     |


### PR DESCRIPTION
1. [Removed](https://docs.neontest.xyz/docs/evm_compatibility/opcodes) BASEFEE from the list of not supported opcodes 
2. [Added ](https://docs.neontest.xyz/docs/evm_compatibility/precompiles) description of neon evm precompiles
3. [Updated](https://docs.neontest.xyz/docs/developing/deploy_facilities/interacting_with_spl_tokens) specification of constructors for ERC20-For-Spl and ERC20-For-Spl-Mintable